### PR TITLE
Done progressive display of the secret image based on correct answers

### DIFF
--- a/src/components/PictureDiscover/PictureDiscover.css
+++ b/src/components/PictureDiscover/PictureDiscover.css
@@ -39,19 +39,7 @@
 			object-fit: cover;
 		}
 
-		.filter-1 .filter-2 {
-			display: none;
-		}
-
-		.filter-3 {
-			display: none;
-		}
-
-		.filter-4 {
-			display: none;
-		}
-
-		.filter-5 {
+		.revealed-group {
 			display: none;
 		}
 	}

--- a/src/components/PictureDiscover/PictureDiscover.tsx
+++ b/src/components/PictureDiscover/PictureDiscover.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router";
 import "./PictureDiscover.css";
 import { secretImg } from "./pictureDiscoverData";
-import type { LevelProps, SecretImgProps } from "./pictureDiscoverType";
+import type { LevelProps, PictureDiscoverProps, SecretImgProps } from "./pictureDiscoverType";
 
 const generateFilterArray = () => {
   const randNumb = [];
@@ -39,7 +39,7 @@ const generateRandomColor = () => {
   return `rgb(${r},${g},${b})`;
 };
 
-const PictureDiscover = () => {
+const PictureDiscover = ({ activeIndex }: PictureDiscoverProps) => {
   const { level } = useParams();
 
   const validateLevel = (lvl: string) => {
@@ -83,9 +83,13 @@ const PictureDiscover = () => {
                 group.map((coord: [number, number]) => {
                   return (
                     <div
-                      className={`filter-${groupIndex + 1}`}
+                      className={`filter-${groupIndex + 1} ${(groupIndex) < activeIndex && "revealed-group"}`}
                       key={`${coord[0]}-${coord[1]}`}
-                      style={{ gridRow: coord[0], gridColumn: coord[1], backgroundColor: groupColors[groupIndex] }}
+                      style={{
+                        gridRow: coord[0],
+                        gridColumn: coord[1],
+                        backgroundColor: groupColors[groupIndex],
+                      }}
                     />)
                 }))
             })

--- a/src/components/PictureDiscover/pictureDiscoverType.tsx
+++ b/src/components/PictureDiscover/pictureDiscoverType.tsx
@@ -4,3 +4,8 @@ export interface SecretImgProps {
 	name: string;
 	imgUrl: string;
 }
+
+
+export interface PictureDiscoverProps {
+	activeIndex: number;
+}

--- a/src/components/Quest/Quest.tsx
+++ b/src/components/Quest/Quest.tsx
@@ -1,15 +1,19 @@
+import { useState } from "react";
 import Navquest from "../NavQuest/Navquest";
 import PictureDiscover from "../PictureDiscover/PictureDiscover";
 import QuizWindow from "../Quiz_Window/QuizWindow";
 import "./Quest.css"
 
 const Quest = () => {
+
+	const [activeIndex, setActiveIndex] = useState<number>(0);
+
 	return (
 		<section className="quest-section">
-			<PictureDiscover />
+			<PictureDiscover activeIndex={activeIndex} />
 			<div className="quiz-container">
 				<Navquest />
-				<QuizWindow />
+				<QuizWindow activeIndex={activeIndex} setActiveIndex={setActiveIndex} />
 			</div>
 		</section>
 	);

--- a/src/components/Quiz_Window/QuizWindow.tsx
+++ b/src/components/Quiz_Window/QuizWindow.tsx
@@ -16,11 +16,14 @@ interface Section {
 	description: string;
 	questions: Question[];
 }
+interface QuizWindowProps {
+	activeIndex: number;
+	setActiveIndex: (value: number) => void;
+}
 
-const QuizWindow = () => {
+const QuizWindow = ({ activeIndex, setActiveIndex }: QuizWindowProps) => {
 	const { level } = useParams() as { level: keyof typeof data.levels };
 	const [sections, setSections] = useState<[string, Section][]>([]);
-	const [activeIndex, setActiveIndex] = useState(0);
 	const [answered, setAnswered] = useState<Record<number, boolean>>({});
 	const [codes, setCodes] = useState<Record<number, string>>({});
 	const [selectedChoices, setSelectedChoices] = useState<


### PR DESCRIPTION
### ✅ What was done

- Lifted the `activeIndex` state up to the `Quest` parent component
- Passed `activeIndex` down as props to both `QuizWindow` and `PictureDiscover`
- Implemented conditional rendering in `PictureDiscover` to reveal parts of a hidden image based on the player's quiz progress
- Cleaned up unused reveal state logic to rely solely on `activeIndex`

### Notes

- This implementation assumes each image group corresponds to a question index (1-to-1 mapping).
- Reveal logic uses `groupIndex < activeIndex` for clarity and simplicity.
- No regression expected as existing logic in `QuizWindow` remains untouched.